### PR TITLE
Make Group Context Extension updates consistent with MLS extensions draft

### DIFF
--- a/draft-ietf-mls-combiner.md
+++ b/draft-ietf-mls-combiner.md
@@ -371,6 +371,8 @@ the traditional session, with considerations to options described in
 
 # Extension Requirements to MLS
 
+## Group Context Extension
+
 The APQInfo struct contains characterizing information to signal to users that
 they are participating in a hybrid session. This is necessary both functionally
 to allow for group synchronization and as a security measure to prevent
@@ -381,53 +383,38 @@ bookkeeping values to validate and synchronize group operations. The `mode`
 is a boolean value: `0` for the default PQ/T Confidentiality Only mode and
 `1` for the PQ/T Confidentiality + Authenticity mode.
 
-The APQInfo struct conforms to the Safe Extensions API (see
-{{!I-D.ietf-mls-extensions}}). Recall that an extension is called *safe* if
-it does not modify base MLS protocol or other MLS extensions beyond using
-components of the Safe Extension API. This allows security analysis of our
-APQ-MLS Combiner protocol in isolation of the security guarantees of the
-base MLS protocol to enable composability of guarantees. The HPMLSInfo
-extension struct SHALL be in the following format:
+APQInfo is stored in the MLS GroupContext of each T and PQ group using the app
+data dictionary mechanism defined in Section 4.6 of
+{{!I-D.ietf-mls-extensions}}. Specifically, the `ComponentData` contains
+`component_id = 0x0006` and `data` set to the following APQInfo struct encoded
+with TLS:
 
-~~~
-      struct{
-          ExtensionType APQ;
-          opaque extension_data<V>;
-          } ExtensionContent;
-
-      struct{
-          opaque t_session_group_id<V>;
-          opaque PQ_session_group_id<V>;
-          bool mode;
-          CipherSuite t_cipher_suite;
-          CipherSuite pq_cipher_suite;
-          uint64 t_epoch;
-          uint64 pq_epoch;
-      } APQInfo
+~~~tls
+struct{
+    opaque t_session_group_id<V>;
+    opaque PQ_session_group_id<V>;
+    bool mode;
+    CipherSuite t_cipher_suite;
+    CipherSuite pq_cipher_suite;
+    uint64 t_epoch;
+    uint64 pq_epoch;
+} APQInfo
 ~~~
 
-## Extension updates and validation
+### Validating APQInfo
 
 As mentioned in {{welcome-message-validation}}, clients MUST validate that
 the information in the APQInfo extensions of both T and PQ group match.
 As the APQInfo contains the epoch of both groups it MUST be updated
-in both groups when doing a FULL Commit. The `update` payload
-MUST update the epochs to the new epochs of both groups (note that the
-epoch of the T group may increment by more than one if one or more
-T only commits have been performed in the interim).
+in both groups when doing a FULL Commit.
 
-~~~
-struct{
-     opaque t_session_group_id<V>;
-     opaque PQ_session_group_id<V>;
-     bool mode;
-     CipherSuite t_cipher_suite;
-     CipherSuite pq_cipher_suite;
-     uint64 t_epoch;
-     uint64 pq_epoch;
-} APQInfo;
-APQInfo APQInfoData;
+### Updating APQInfo
 
+The APQInfo is updated using AppDataUpdate proposal defined in Section 4.7
+of {{!I-D.ietf-mls-extensions}}. The `update` payload for APQInfo is the
+following struct serialized with TLS:
+
+~~~tls
 enum {
     full_update (0),
     new_t_epoch(1),
@@ -441,11 +428,29 @@ struct {
         case full_update:
             APQInfo new_apq_info;
         case new_t_epoch:
-            uint64 epoch;
+            uint64 new_t_epoch;
         case new_pq_epoch:
-            uint64 epoch;
+            uint64 new_pq_epoch;
 } APQInfoUpdate;
 ~~~
+
+The mechanism for applying AppDataUpdate in {{!I-D.ietf-mls-extensions}}
+is generic over a function to turn an `update` into a new app data object
+provided by the application component. For APQInfo the new APQInfo object
+if determined as follows:
+
+* If `update_type` is `full_update` then the new object is `new_apq_info`.
+* If `update_type` is `new_t_epoch` then the new object is the same as the
+  old object but with `t_epoch` set to `new_t_epoch`.
+* If `update_type` is `new_pq_epoch` then the new object is the same as the
+  old object but with `pq_epoch` and `t_epoch` set to `new_pq_epoch` and
+  `new_t_epoch`, respectively.
+
+A full commit MUST update the epochs to the new epochs of both groups
+(note that the epoch of the T group may increment by more than one if one
+or more T only commits have been performed in the interim). That is, the
+commits of both T and PQ groups each includes two AppDataUpdate proposals,
+one incrementing the T epoch and one incrementing the PQ epoch. 
 
 Consequently, when processing a FULL Commit, recipients MUST verify that
 the epoch set by the APQInfoUpdate matches the actual (new) epoch of

--- a/draft-ietf-mls-combiner.md
+++ b/draft-ietf-mls-combiner.md
@@ -392,7 +392,7 @@ with TLS:
 ~~~tls
 struct{
     opaque t_session_group_id<V>;
-    opaque PQ_session_group_id<V>;
+    opaque pq_session_group_id<V>;
     bool mode;
     CipherSuite t_cipher_suite;
     CipherSuite pq_cipher_suite;
@@ -452,9 +452,9 @@ in the proposal payload.
 
 A Commit can include either a single AppDataUpdate with a `full_update` or
 two proposals; one with `new_t_epoch` and one with `new_pq_epoch`. In the
-later case, the Commit MUST be applied to applied to an old epoch that already
+latter case, the Commit MUST be applied to an old epoch that already
 has an APQInfo in its GroupContext and applying the two proposals produces the
-same APQInfo for the new epoch, except that the epoch fields are over written
+same APQInfo for the new epoch, except that the epoch fields are overwritten
 with those in the proposals.
 
 If this is the first FULL Commit in the APQ-MLS group, then the corresponding
@@ -463,11 +463,11 @@ AppDataUpdate proposal and the epochs in `new_pq_info` MUST be set to the
 epochs of the two MLS groups after the respective Commit was applied.
 
 In subsequent FULL Commits, the APQInfo in both MLS groups' GroupContext
-structs MUST be updated to reflect the new epochs and any changes to cipher
-suites and APQ mode (PARTIAL or FULL). This can be done using a `full_update`
-AppDataUpdate proposal. Alternatively, if no changes are being made to the
-cipher suites or APQ-MLS mode, than the second method using `new_t_epoch` and
-`new_pq_epoch` can be used.
+structs MUST be updated to reflect the new epochs and any changes to APQ mode
+(PQ Confidentiality-Only or PQ Confidentiality+Authenticity). This can be done
+using a `full_update` AppDataUpdate proposal. Alternatively, if no changes are
+being made to the cipher suites or APQ-MLS mode, than the second method using
+`new_t_epoch` and `new_pq_epoch` can be used.
 
 Either way, for any FULL Commit, recipients MUST verify that the epoch
 fields in the APQInfo structs included in the GroupContext of the new epochs

--- a/draft-ietf-mls-combiner.md
+++ b/draft-ietf-mls-combiner.md
@@ -376,16 +376,16 @@ the traditional session, with considerations to options described in
 The APQInfo struct contains characterizing information to signal to users that
 they are participating in a hybrid session. This is necessary both functionally
 to allow for group synchronization and as a security measure to prevent
-downgrading attacks to coax users into parcipating in just one of the two
+downgrading attacks that coax users into parcipating in just one of the two
 sessions. The `group_id`, `cipher_suite`, and `epoch` from both sessions
 (`t` for the traditional session and `pq` for the PQ session) are used as
 bookkeeping values to validate and synchronize group operations. The `mode`
 is a boolean value: `0` for the default PQ/T Confidentiality Only mode and
 `1` for the PQ/T Confidentiality + Authenticity mode.
 
-APQInfo is stored in the MLS GroupContext of each T and PQ group using the app
-data dictionary mechanism defined in Section 4.6 of
-{{!I-D.ietf-mls-extensions}}. Specifically, the `ComponentData` contains
+APQInfo is stored in the MLS GroupContext of both the T and PQ groups using the
+app data dictionary mechanism defined in Section 4.6 of
+{{!I-D.ietf-mls-extensions}}. Specifically, the ComponentData contains
 `component_id = 0x0006` and `data` set to the following APQInfo struct encoded
 with TLS:
 
@@ -401,18 +401,12 @@ struct{
 } APQInfo
 ~~~
 
-### Validating APQInfo
-
-As mentioned in {{welcome-message-validation}}, clients MUST validate that
-the information in the APQInfo extensions of both T and PQ group match.
-As the APQInfo contains the epoch of both groups it MUST be updated
-in both groups when doing a FULL Commit.
-
 ### Updating APQInfo
 
-The APQInfo is updated using AppDataUpdate proposal defined in Section 4.7
-of {{!I-D.ietf-mls-extensions}}. The `update` payload for APQInfo is the
-following struct serialized with TLS:
+The APQInfo structs in both groups are created and modified using AppDataUpdate
+proposals defined in Section 4.7 of {{!I-D.ietf-mls-extensions}}. For this,
+the `update` field in an AppDataUpdate  contains a TLS serialized instance of
+the APQInfoUpdate struct:
 
 ~~~tls
 enum {
@@ -434,27 +428,58 @@ struct {
 } APQInfoUpdate;
 ~~~
 
-The mechanism for applying AppDataUpdate in {{!I-D.ietf-mls-extensions}}
-is generic over a function to turn an `update` into a new app data object
-provided by the application component. For APQInfo the new APQInfo object
-if determined as follows:
+To apply an AppDataUpdate proposal, the mechanism in
+{{!I-D.ietf-mls-extensions}} requires that the application provide a function
+to convert an `update` from the proposal's payload into a new ComponentData
+object. For APQ-MLS, the resulting ComponentData object is then included in
+the AppDataDictionary struct which is part of the GroupContext as specified
+in {{!I-D.ietf-mls-extensions}}.
 
-* If `update_type` is `full_update` then the new object is `new_apq_info`.
-* If `update_type` is `new_t_epoch` then the new object is the same as the
-  old object but with `t_epoch` set to `new_t_epoch`.
-* If `update_type` is `new_pq_epoch` then the new object is the same as the
-  old object but with `pq_epoch` and `t_epoch` set to `new_pq_epoch` and
-  `new_t_epoch`, respectively.
+For APQ-MLS, the `update` field in the AppDataUpdate proposal defines either
+an entirely new APQInfo, or modifies an existing one, using one of following
+two methods.
 
-A full commit MUST update the epochs to the new epochs of both groups
-(note that the epoch of the T group may increment by more than one if one
-or more T only commits have been performed in the interim). That is, the
-commits of both T and PQ groups each includes two AppDataUpdate proposals,
-one incrementing the T epoch and one incrementing the PQ epoch.
+1. If the AppDataUpdate has (`component_id = 0x0006` and) `update_type` set
+to `full_update`, then it's `new_apq_info` field MUST contain a TLS serialize
+instance of a complete APQInfo for inclusion in the GroupContext.
 
-Consequently, when processing a FULL Commit, recipients MUST verify that
-the epoch set by the APQInfoUpdate matches the actual (new) epoch of
-both groups.
+2. If instead AppDataUpdate proposal has (`component_id = 0x0006` and)
+`update_type` set to `new_t_epoch` then an existing APQInfo is modified by
+replacing the `t_epoch` field with the `uint64 new_t_epoch` field from the
+proposal. Similarly, using the `new_pq_epoch` update type, the AppDataUpdate
+proposal replaces the PQ MLS group's epoch with the `uint64 new_pq_epoch` value
+in the proposal payload.
+
+A Commit can include either a single AppDataUpdate with a `full_update` or
+two proposals; one with `new_t_epoch` and one with `new_pq_epoch`. In the
+later case, the Commit MUST be applied to applied to an old epoch that already
+has an APQInfo in its GroupContext and applying the two proposals produces the
+same APQInfo for the new epoch, except that the epoch fields are over written
+with those in the proposals.
+
+If this is the first FULL Commit in the APQ-MLS group, then the corresponding
+Commits to the T and to the PQ MLS groups MUST contain a `full_update`
+AppDataUpdate proposal and the epochs in `new_pq_info` MUST be set to the
+epochs of the two MLS groups after the respective Commit was applied.
+
+In subsequent FULL Commits, the APQInfo in both MLS groups' GroupContext
+structs MUST be updated to reflect the new epochs and any changes to cipher
+suites and APQ mode (PARTIAL or FULL). This can be done using a `full_update`
+AppDataUpdate proposal. Alternatively, if no changes are being made to the
+cipher suites or APQ-MLS mode, than the second method using `new_t_epoch` and
+`new_pq_epoch` can be used.
+
+Either way, for any FULL Commit, recipients MUST verify that the epoch
+fields in the APQInfo structs included in the GroupContext of the new epochs
+both have cipher suites and epochs matching those of the two new epochs
+created by the FULL Commit.
+
+### Validating APQInfo
+
+As mentioned in {{welcome-message-validation}}, clients MUST validate that
+the information in the APQInfo extensions of both T and PQ group match.
+As the APQInfo contains the epoch of both groups it MUST be updated
+in both groups when doing a FULL Commit.
 
 ## Key Schedule {#key-schedule}
 

--- a/draft-ietf-mls-combiner.md
+++ b/draft-ietf-mls-combiner.md
@@ -373,15 +373,16 @@ the traditional session, with considerations to options described in
 
 ## Group Context Extension
 
-The APQInfo struct contains characterizing information to signal to users that
-they are participating in a hybrid session. This is necessary both functionally
-to allow for group synchronization and as a security measure to prevent
-downgrading attacks that coax users into parcipating in just one of the two
-sessions. The `group_id`, `cipher_suite`, and `epoch` from both sessions
-(`t` for the traditional session and `pq` for the PQ session) are used as
-bookkeeping values to validate and synchronize group operations. The `mode`
-is a boolean value: `0` for the default PQ/T Confidentiality Only mode and
-`1` for the PQ/T Confidentiality + Authenticity mode.
+The APQInfo struct contains information characterizing the APQInfo session to
+signal to users that they are participating in a hybrid session. This is
+necessary both functionally to allow for group synchronization and as a
+security measure to prevent downgrading attacks that coax users into
+parcipating in just one of the two sessions. The `group_id`, `cipher_suite`,
+and `epoch` from both sessions (`t` for the traditional session and `pq` for
+the PQ session) are used as bookkeeping values to validate and synchronize
+group operations. The `mode` is a boolean value: `0` for the default PQ/T
+Confidentiality Only mode and `1` for the PQ/T Confidentiality + Authenticity
+mode.
 
 APQInfo is stored in the MLS GroupContext of both the T and PQ groups using the
 app data dictionary mechanism defined in Section 4.6 of
@@ -390,7 +391,7 @@ app data dictionary mechanism defined in Section 4.6 of
 with TLS:
 
 ~~~tls
-struct{
+struct {
     opaque t_session_group_id<V>;
     opaque pq_session_group_id<V>;
     bool mode;
@@ -439,11 +440,12 @@ For APQ-MLS, the `update` field in the AppDataUpdate proposal defines either
 an entirely new APQInfo, or modifies an existing one, using one of following
 two methods.
 
-1. If the AppDataUpdate has (`component_id = 0x0006` and) `update_type` set
-to `full_update`, then it's `new_apq_info` field MUST contain a TLS serialize
-instance of a complete APQInfo for inclusion in the GroupContext.
+1. If the AppDataUpdate has its `component_id` set to `0x0006` and
+`update_type` set to `full_update`, then it's `new_apq_info` field MUST contain
+a TLS serialize instance of a complete APQInfo for inclusion in the
+GroupContext.
 
-2. If instead AppDataUpdate proposal has (`component_id = 0x0006` and)
+2. If instead AppDataUpdate proposal its `component_id` set to `0x0006` and its
 `update_type` set to `new_t_epoch` then an existing APQInfo is modified by
 replacing the `t_epoch` field with the `uint64 new_t_epoch` field from the
 proposal. Similarly, using the `new_pq_epoch` update type, the AppDataUpdate
@@ -454,15 +456,15 @@ A Commit can include either a single AppDataUpdate with a `full_update` or
 two proposals; one with `new_t_epoch` and one with `new_pq_epoch`. In the
 latter case, the Commit MUST be applied to an old epoch that already
 has an APQInfo in its GroupContext and applying the two proposals produces the
-same APQInfo for the new epoch, except that the epoch fields are overwritten
-with those in the proposals.
+same APQInfo for the new epoch, except that the two epoch fields are
+overwritten with those in the proposals.
 
 If this is the first FULL Commit in the APQ-MLS group, then the corresponding
 Commits to the T and to the PQ MLS groups MUST contain a `full_update`
 AppDataUpdate proposal and the epochs in `new_pq_info` MUST be set to the
 epochs of the two MLS groups after the respective Commit was applied.
 
-In subsequent FULL Commits, the APQInfo in both MLS groups' GroupContext
+In all subsequent FULL Commits, the APQInfo in both MLS groups' GroupContext
 structs MUST be updated to reflect the new epochs and any changes to APQ mode
 (PQ Confidentiality-Only or PQ Confidentiality+Authenticity). This can be done
 using a `full_update` AppDataUpdate proposal. Alternatively, if no changes are

--- a/draft-ietf-mls-combiner.md
+++ b/draft-ietf-mls-combiner.md
@@ -450,7 +450,7 @@ A full commit MUST update the epochs to the new epochs of both groups
 (note that the epoch of the T group may increment by more than one if one
 or more T only commits have been performed in the interim). That is, the
 commits of both T and PQ groups each includes two AppDataUpdate proposals,
-one incrementing the T epoch and one incrementing the PQ epoch. 
+one incrementing the T epoch and one incrementing the PQ epoch.
 
 Consequently, when processing a FULL Commit, recipients MUST verify that
 the epoch set by the APQInfoUpdate matches the actual (new) epoch of


### PR DESCRIPTION
Addresses #6 

The PR also removes duplicate definition of APQInfo and adds a more precise description of how the extension is updated (the mechanism was implicit before).