### PR TITLE
Rename DeriveExtensionSecret to SafeExportSecret

### DIFF
--- a/draft-ietf-mls-combiner.md
+++ b/draft-ietf-mls-combiner.md
@@ -173,8 +173,8 @@ Commits to proposals MAY be *PARTIAL* or *FULL*. For a PARTIAL Commit, only the
 traditional session's epoch is updated following the Propose-Commit sequence from
 Section 12 of {{RFC9420}}. For a FULL Commit, a Commit is first applied to the PQ
 session and another Commit is applied to the traditional session using a PSK
-derived from the PQ session using the DeriveExtensionSecret and `apq_psk` label
-(see {{key-schedule}}). To ensure the correct PSK is imported into the traditional
+derived from the PQ session using SafeExportSecret with the `apq_mls_info`
+component ID `0x0006` (see {{key-schedule}}). To ensure the correct PSK is imported into the traditional
 session, the sender includes information about the PSK in a PreSharedKey proposal
 for the Commit list of proposals from the traditional session. The information about the
 exported PSK is captured (shown '=' in the figures below for illustration purposes)
@@ -189,7 +189,7 @@ session.
     |                                        |                            |
     | Commit'()                              |                            |
     |    PresharedKeyID =                    |                            |
-    |    DeriveExtensionSecret('apq_psk')    |                            |
+    |    SafeExportSecret(0x0006)            |                            |
     | Commit(PreSharedKeyID)                 |                            |
     |-------------------------------------------------------------------->|
     |                                        |                            |
@@ -219,7 +219,7 @@ session.
     |                                        |                                |
     | Commit'(Upd')                          |                                |
     |    PresharedKeyID =                    |                                |
-    |    DeriveExtensionSecret('apq_psk')    |                                |
+    |    SafeExportSecret(0x0006)            |                                |
     | Commit(Upd, PreSharedKeyID)            |                                |
     |------------------------------------------------------------------------>|
     |                                        |                                |
@@ -258,7 +258,7 @@ the joiner.
     |<-----------------------------------------+                         |
     | Commit'(Add'(KeyPackageB'))              |                         |
     |   PresharedKeyID =                       |                         |
-    |   DeriveExtensionSecret('apq_psk')       |                         |
+    |   SafeExportSecret(0x0006)               |                         |
     | Commit(Add(KeyPackageB), PreSharedKeyID) |                         |
     +------------------------------------------------------------------->|
     |                         |                |                         |
@@ -534,7 +534,7 @@ DeriveSecret(., "psk")
                                         |    = <secret>
                                       [...]
     Fig 3: The apq_psk of the PQ session is injected into the key schedule of the
-    traditional session using the safe extensions API DeriveExtensionSecret.
+    traditional session using the safe extensions API SafeExportSecret.
 ~~~
 
 


### PR DESCRIPTION
The commit-flow prose and the figures called the export function DeriveExtensionSecret('apq_psk'), contradicting the Key Schedule section, which mandates SafeExportSecret and forbids using the extension_secret. Rename all occurrences to SafeExportSecret(0x0006) to match the Safe Extensions API in draft-ietf-mls-extensions.

Fixes #14