### PR TITLE
Specify the KDF for the apq_psk_id and apq_psk derivations

### DIFF
--- a/draft-ietf-mls-combiner.md
+++ b/draft-ietf-mls-combiner.md
@@ -187,7 +187,7 @@ session.
       A                                      B                         Channel
     |                                        |                            |
     | Commit'()                              |                            |
-    |    PresharedKeyID =                    |                            |
+    |    PreSharedKeyID =                    |                            |
     |    SafeExportSecret(0x0006)            |                            |
     | Commit(PreSharedKeyID)                 |                            |
     |-------------------------------------------------------------------->|
@@ -217,7 +217,7 @@ session.
     |                                        |<-------------------------------+
     |                                        |                                |
     | Commit'(Upd')                          |                                |
-    |    PresharedKeyID =                    |                                |
+    |    PreSharedKeyID =                    |                                |
     |    SafeExportSecret(0x0006)            |                                |
     | Commit(Upd, PreSharedKeyID)            |                                |
     |------------------------------------------------------------------------>|
@@ -256,7 +256,7 @@ the joiner.
     |                         |    KeyPackageB |                         |
     |<-----------------------------------------+                         |
     | Commit'(Add'(KeyPackageB'))              |                         |
-    |   PresharedKeyID =                       |                         |
+    |   PreSharedKeyID =                       |                         |
     |   SafeExportSecret(0x0006)               |                         |
     | Commit(Add(KeyPackageB), PreSharedKeyID) |                         |
     +------------------------------------------------------------------->|
@@ -509,20 +509,17 @@ in both groups when doing a FULL Commit.
 ## Key Schedule {#key-schedule}
 
 The `apq_psk` exporter key derived in the PQ session MUST be derived in
-accordance with the Safe Extensions API guidance (see Exporting Secrets
+accordance with the Safe Extensions API guidance (see Exported Secrets
 in {{I-D.ietf-mls-extensions}}). In particular, it SHALL NOT use the
 `extension_secret` and MUST be derived using the SafeExportSecret
-function as defined in Section 4.4 Pre-Shared Keys of
+function as defined in Section 4.4 Exported Secrets of
 {{I-D.ietf-mls-extensions}}. This is to ensure forward secrecy
 guarantees (see {{security-considerations}}).
 
 The SafeExportSecret computation takes place in the PQ session and
 therefore uses the KDF of the PQ session's cipher suite. The two
-subsequent derivations of `apq_psk_id` and `apq_psk` (marked with `*`
-in Fig 3) MUST use the KDF of the traditional session's cipher suite.
-This is because the resulting `apq_psk` is consumed by the key
-schedule of the traditional session and the PreSharedKeyID
-identifying it is an object of the traditional session.
+subsequent derivations of `apq_psk_id` and `apq_psk` MUST use the KDF
+of the traditional session's cipher suite.
 
 Even though the `apq_psk` PSK is not sent over the wire, members of
 the APQ-MLS session must agree on the value of which PSK to use. In
@@ -540,18 +537,20 @@ used SHALL set `PSKType = 3` and `component_id = 0x0006` (see Section
           V
     apq_exporter
           |
-          +--> DeriveSecret(., "psk_id")*
-          |    = apq_psk_id
-          V
-DeriveSecret(., "psk")*
+          +-----------> DeriveSecret(apq_exporter, "psk_id")
+          |             = apq_psk_id
           |
-          V                            [...]
-       apq_psk                     joiner_secret
-          |                             |
-          |                             |
-          |                             V
-          +--> <psk_secret (or 0)> --> KDF.Extract
-        [...]                           |
+          +-----------> DeriveSecret(apq_exporter, "psk")
+        [...]           |
+                        V
+                     apq_psk
+                        |
+                        |              [...]
+                        |          joiner_secret
+                        |               |
+                        V               V
+               <psk_secret (or 0)> --> KDF.Extract
+                                        |
                                         |
                                         +--> DeriveSecret(., "welcome")
                                         |    = welcome_secret

--- a/draft-ietf-mls-combiner.md
+++ b/draft-ietf-mls-combiner.md
@@ -490,6 +490,14 @@ function as defined in Section 4.4 Pre-Shared Keys of
 {{I-D.ietf-mls-extensions}}. This is to ensure forward secrecy
 guarantees (see {{security-considerations}}).
 
+The SafeExportSecret computation takes place in the PQ session and
+therefore uses the KDF of the PQ session's cipher suite. The two
+subsequent derivations of `apq_psk_id` and `apq_psk` (marked with `*`
+in Fig 3) MUST use the KDF of the traditional session's cipher suite.
+This is because the resulting `apq_psk` is consumed by the key
+schedule of the traditional session and the PreSharedKeyID
+identifying it is an object of the traditional session.
+
 Even though the `apq_psk` PSK is not sent over the wire, members of
 the APQ-MLS session must agree on the value of which PSK to use. In
 alignment with the Safe Extensions API policy for PSKs, APQ-MLS PSKs
@@ -506,10 +514,10 @@ used SHALL set `PSKType = 3` and `component_id = 0x0006` (see Section
           V
     apq_exporter
           |
-          +--> DeriveSecret(., "psk_id")
+          +--> DeriveSecret(., "psk_id")*
           |    = apq_psk_id
           V
-DeriveSecret(., "psk")
+DeriveSecret(., "psk")*
           |
           V                            [...]
        apq_psk                     joiner_secret


### PR DESCRIPTION
The draft never said which session's KDF computes
DeriveSecret(apq_exporter, "psk_id") and DeriveSecret(apq_exporter, "psk"), and Fig 3 placed both derivations in the PQ session column. SafeExportSecret itself is computed with the PQ session's KDF, but the two subsequent derivations MUST use the traditional session's KDF, since the PSK is consumed by the traditional key schedule and the PreSharedKeyID lives in the traditional session.

Fixes #12